### PR TITLE
pydantic base for parsl configurations.

### DIFF
--- a/deepdrivemd/api.py
+++ b/deepdrivemd/api.py
@@ -21,12 +21,7 @@ from deepdrivemd.applications.openmm_simulation import (
     SimulationFromPDB,
     SimulationFromRestart,
 )
-from deepdrivemd.config import (
-    ApplicationSettings,
-    BaseComputeSettings,
-    BaseSettings,
-    path_validator,
-)
+from deepdrivemd.config import ApplicationSettings, BaseSettings, path_validator
 
 
 class DeepDriveMDSettings(BaseSettings):
@@ -53,8 +48,6 @@ class DeepDriveMDSettings(BaseSettings):
     """Number of simulation results to use between model training tasks."""
     simulations_per_inference: int
     """Number of simulation results to use between inference tasks."""
-    compute_settings: BaseComputeSettings
-    """Compute settings (HPC platform, number of GPUs, etc)."""
 
     # Application settings (should be overriden)
     simulation_settings: ApplicationSettings

--- a/deepdrivemd/api.py
+++ b/deepdrivemd/api.py
@@ -21,7 +21,12 @@ from deepdrivemd.applications.openmm_simulation import (
     SimulationFromPDB,
     SimulationFromRestart,
 )
-from deepdrivemd.config import ApplicationSettings, BaseSettings, path_validator
+from deepdrivemd.config import (
+    ApplicationSettings,
+    BaseComputeSettings,
+    BaseSettings,
+    path_validator,
+)
 
 
 class DeepDriveMDSettings(BaseSettings):
@@ -48,8 +53,10 @@ class DeepDriveMDSettings(BaseSettings):
     """Number of simulation results to use between model training tasks."""
     simulations_per_inference: int
     """Number of simulation results to use between inference tasks."""
+    compute_settings: BaseComputeSettings
+    """Compute settings (HPC platform, number of GPUs, etc)."""
 
-    # Application settings
+    # Application settings (should be overriden)
     simulation_settings: ApplicationSettings
     train_settings: ApplicationSettings
     inference_settings: ApplicationSettings

--- a/deepdrivemd/config.py
+++ b/deepdrivemd/config.py
@@ -1,8 +1,10 @@
 import json
+from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional, Type, TypeVar, Union
+from typing import Literal, Optional, Type, TypeVar, Union
 
 import yaml
+from parsl.config import Config
 from pydantic import BaseSettings as _BaseSettings
 from pydantic import validator
 
@@ -49,3 +51,24 @@ class ApplicationSettings(BaseSettings):
         v = v.resolve()
         v.mkdir(exist_ok=True, parents=True)
         return v
+
+
+class BaseComputeSettings(BaseSettings, ABC):
+    name: Literal[""] = ""
+    """Name of the platform to use."""
+
+    @abstractmethod
+    def config_factory(self, run_dir: PathLike) -> Config:
+        """Create a new Parsl configuration.
+
+        Parameters
+        ----------
+        run_dir : PathLike
+            Path to store monitoring DB and parsl logs.
+
+        Returns
+        -------
+        Config
+            Parsl configuration.
+        """
+        ...

--- a/deepdrivemd/config.py
+++ b/deepdrivemd/config.py
@@ -1,10 +1,8 @@
 import json
-from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Literal, Optional, Type, TypeVar, Union
+from typing import Optional, Type, TypeVar, Union
 
 import yaml
-from parsl.config import Config
 from pydantic import BaseSettings as _BaseSettings
 from pydantic import validator
 
@@ -51,24 +49,3 @@ class ApplicationSettings(BaseSettings):
         v = v.resolve()
         v.mkdir(exist_ok=True, parents=True)
         return v
-
-
-class BaseComputeSettings(BaseSettings, ABC):
-    name: Literal[""] = ""
-    """Name of the platform to use."""
-
-    @abstractmethod
-    def config_factory(self, run_dir: PathLike) -> Config:
-        """Create a new Parsl configuration.
-
-        Parameters
-        ----------
-        run_dir : PathLike
-            Path to store monitoring DB and parsl logs.
-
-        Returns
-        -------
-        Config
-            Parsl configuration.
-        """
-        ...

--- a/deepdrivemd/parsl.py
+++ b/deepdrivemd/parsl.py
@@ -1,58 +1,62 @@
 """Utilities to build Parsl configurations."""
+from typing import Literal, Tuple, Union
+
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import LocalProvider
 
-from deepdrivemd.config import PathLike
+from deepdrivemd.config import BaseComputeSettings, PathLike
 
 
-def create_workstation_config(
-    run_dir: PathLike, available_accelerators: int = 8
-) -> Config:
-    """Configuration for workstation.
+class LocalSettings(BaseComputeSettings):
+    name: Literal["local"] = "local"
+    max_workers: int = 1
+    cores_per_worker: float = 0.0001
+    worker_port_range: Tuple[int, int] = (10000, 20000)
+    label: str = "htex"
 
-    Parameters
-    ----------
-    run_dir : PathLike
-        Path to store monitoring DB and parsl logs.
-    available_accelerators : int
-        Number of GPU accelerators to use.
-
-    Returns
-    -------
-    Config
-        Parsl configuration.
-    """
-    config = Config(
-        run_dir=str(run_dir),
-        retries=1,
-        executors=[
-            HighThroughputExecutor(
-                address="localhost",
-                label="htex",
-                cpu_affinity="block",
-                available_accelerators=available_accelerators,
-                worker_port_range=(10000, 20000),
-                provider=LocalProvider(init_blocks=1, max_blocks=1),
-            ),
-        ],
-    )
-
-    return config
+    def config_factory(self, run_dir: PathLike) -> Config:
+        return Config(
+            run_dir=str(run_dir),
+            strategy=None,
+            executors=[
+                HighThroughputExecutor(
+                    address="localhost",
+                    label=self.label,
+                    max_workers=self.max_workers,
+                    cores_per_worker=self.cores_per_worker,
+                    worker_port_range=self.worker_port_range,
+                    provider=LocalProvider(init_blocks=1, max_blocks=1),
+                ),
+            ],
+        )
 
 
-def create_local_configuration(run_dir: PathLike) -> Config:
-    return Config(
-        executors=[
-            HighThroughputExecutor(
-                address="localhost",
-                label="htex",
-                max_workers=1,
-                cores_per_worker=0.0001,
-                worker_port_range=(10000, 20000),
-                provider=LocalProvider(init_blocks=1, max_blocks=1),
-            ),
-        ],
-        strategy=None,
-        run_dir=str(run_dir),
-    )
+class WorkstationSettings(BaseComputeSettings):
+    name: Literal["workstation"] = "workstation"
+    """Name of the platform."""
+    available_accelerators: int = 8
+    """Number of GPU accelerators to use."""
+    worker_port_range: Tuple[int, int] = (10000, 20000)
+    """Port range."""
+    label: str = "htex"
+    retries: int = 1
+
+    def config_factory(self, run_dir: PathLike) -> Config:
+        return Config(
+            run_dir=str(run_dir),
+            retries=self.retries,
+            executors=[
+                HighThroughputExecutor(
+                    address="localhost",
+                    label=self.label,
+                    cpu_affinity="block",
+                    available_accelerators=self.available_accelerators,
+                    worker_port_range=self.worker_port_range,
+                    provider=LocalProvider(init_blocks=1, max_blocks=1),
+                ),
+            ],
+        )
+
+
+ComputeSettingsTypes = Union[LocalSettings, WorkstationSettings]

--- a/deepdrivemd/parsl.py
+++ b/deepdrivemd/parsl.py
@@ -1,11 +1,35 @@
 """Utilities to build Parsl configurations."""
+from abc import ABC, abstractmethod
 from typing import Literal, Tuple, Union
 
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 from parsl.providers import LocalProvider
 
-from deepdrivemd.config import BaseComputeSettings, PathLike
+from deepdrivemd.config import BaseSettings, PathLike
+
+
+class BaseComputeSettings(BaseSettings, ABC):
+    """Compute settings (HPC platform, number of GPUs, etc)."""
+
+    name: Literal[""] = ""
+    """Name of the platform to use."""
+
+    @abstractmethod
+    def config_factory(self, run_dir: PathLike) -> Config:
+        """Create a new Parsl configuration.
+
+        Parameters
+        ----------
+        run_dir : PathLike
+            Path to store monitoring DB and parsl logs.
+
+        Returns
+        -------
+        Config
+            Parsl configuration.
+        """
+        ...
 
 
 class LocalSettings(BaseComputeSettings):

--- a/deepdrivemd/workflows/openmm_cvae.py
+++ b/deepdrivemd/workflows/openmm_cvae.py
@@ -170,7 +170,8 @@ if __name__ == "__main__":
         return_type=CVAEInferenceOutput,
     )
 
-    # Define the worker configuration
+    # Define the parsl configuration (this can be done using the config_factory
+    # for common use cases or by defining your own configuration.)
     parsl_config = cfg.compute_settings.config_factory(cfg.run_dir / "run-info")
 
     doer = ParslTaskServer(

--- a/deepdrivemd/workflows/openmm_cvae.py
+++ b/deepdrivemd/workflows/openmm_cvae.py
@@ -30,7 +30,7 @@ from deepdrivemd.applications.openmm_simulation import (
     MDSimulationSettings,
     SimulationFromRestart,
 )
-from deepdrivemd.parsl import create_local_configuration
+from deepdrivemd.parsl import ComputeSettingsTypes
 from deepdrivemd.utils import application, register_application
 
 
@@ -117,6 +117,7 @@ class ExperimentSettings(DeepDriveMDSettings):
     simulation_settings: MDSimulationSettings
     train_settings: CVAETrainSettings
     inference_settings: CVAEInferenceSettings
+    compute_settings: ComputeSettingsTypes
 
 
 if __name__ == "__main__":
@@ -170,7 +171,7 @@ if __name__ == "__main__":
     )
 
     # Define the worker configuration
-    parsl_config = create_local_configuration(cfg.run_dir / "run-info")
+    parsl_config = cfg.compute_settings.config_factory(cfg.run_dir / "run-info")
 
     doer = ParslTaskServer(
         [run_simulation, run_train, run_inference], queues, parsl_config

--- a/tests/basic-local/test.yaml
+++ b/tests/basic-local/test.yaml
@@ -4,6 +4,9 @@ simulations_per_train: 2
 simulations_per_inference: 2
 num_total_simulations: 4
 
+compute_settings:
+  name: local
+
 simulation_settings:
   simulation_length_ns: 1
   rmsd_reference_pdb: data/1fme/1FME-folded.pdb


### PR DESCRIPTION
Allow full control of parsl configuration from input YAML file. For the workstation case:
```
compute_settings:
  name: workstation
  available_accelerators: 4
```

Cons: The BaseComputeSettings currently requires an abstract function to return a Parsl Config object which couples the runtime to Parsl. This could be generalized down the road with minimal changes. 

What do you think @WardLT ?